### PR TITLE
spp-7695 remove question marks

### DIFF
--- a/content/help_centre/help_centre.json
+++ b/content/help_centre/help_centre.json
@@ -6,11 +6,11 @@
             "subcategories": [
                 {
                     "name": "view-methods",
-                    "label": "How to find and view methods?"
+                    "label": "How to find and view methods"
                 },
                 {
                     "name": "methods-request",
-                    "label": "How to submit a method request?"
+                    "label": "How to submit a method request"
                 },
                 {
                     "name": "coding-standards",
@@ -24,11 +24,11 @@
             "subcategories": [
                 {
                     "name": "run-a-method",
-                    "label": "How to use a method?"
+                    "label": "How to use a method"
                 },
                 {
                     "name": "access-specification-code",
-                    "label": "How to access a method specification and code?"
+                    "label": "How to access a method specification and code"
                 }
             ]
         },
@@ -38,11 +38,11 @@
             "subcategories": [
                 {
                     "name": "report-bug",
-                    "label": "How to report a code defect or bug?"
+                    "label": "How to report a code defect or bug"
                 },
                 {
                     "name": "provide-feedback",
-                    "label": "How to provide feedback?"
+                    "label": "How to provide feedback"
                 }
             ]
         },
@@ -52,11 +52,11 @@
             "subcategories": [
                 {
                     "name": "support",
-                    "label": "How to get support?"
+                    "label": "How to get support"
                 },
                 {
                     "name": "expert-groups",
-                    "label": "How to get more information on Expert groups?"
+                    "label": "How to get more information on Expert groups"
                 }
             ]
         }

--- a/content/other/help-pages.jsonnet
+++ b/content/other/help-pages.jsonnet
@@ -5,11 +5,11 @@
         "subcategories":[
             {
                 "name":"view_methods",
-                "label": "How to find and view methods?"
+                "label": "How to find and view methods"
             },
             {
                 "name":"methods_request",
-                "label": "How to submit a method request?"
+                "label": "How to submit a method request"
             },
             {
                 "name":"coding_standards",
@@ -23,11 +23,11 @@
         "subcategories":[
             {
                 "name":"run_a_method",
-                "label": "How to use a method?"
+                "label": "How to use a method"
             },
             {
                 "name":"access_specification",
-                "label": "How to access a method specification and code?"
+                "label": "How to access a method specification and code"
             }
         ]
     },
@@ -37,11 +37,11 @@
         "subcategories":[
             {
                 "name":"bug_report",
-                "label": "How to report a code defect or bug?"
+                "label": "How to report a code defect or bug"
             },
             {
                 "name":"provide_feedback",
-                "label": "How to provide feedback?"
+                "label": "How to provide feedback"
             }
         ]
     },
@@ -51,7 +51,7 @@
         "subcategories":[
             {
                 "name":"support",
-                "label": "How to get support?"
+                "label": "How to get support"
             }
         ]
     }


### PR DESCRIPTION
Description:
This story is about removing superfluous question marks in the help centre and in the click through page associated with each link.