### PR TITLE
spp-7696 change hyperlink to expert groups

### DIFF
--- a/content/glossary/expert-group.jsonnet
+++ b/content/glossary/expert-group.jsonnet
@@ -1,7 +1,7 @@
 {
   term: 'Expert group',
-  external_links: [{'link': 'https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/methodology/information-on-specific-methods/#analysis', 'text': 'Expert group'}],
+  external_links: [{'link': 'https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/methodology/information-on-specific-methods/', 'text': 'Expert group'}],
   meaning: |||
-    A group of ONS employees within the Methodology and Quality Directorate with expertise in a specific area. For a full list, see https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/methodology/information-on-specific-methods/#analysis
+    A group of ONS employees within the Methodology and Quality Directorate with expertise in a specific area. For a full list, see https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/methodology/information-on-specific-methods/
   |||
 }


### PR DESCRIPTION
Description:

This story is about changing the link in the glossary that points to further information about Expert Groups. 

It currently points to https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/methodology/information-on-specific-methods/#analysis

It needs to change to point to 

[Information on specific statistical methods – Government Analysis Function (civilservice.gov.uk)](https://analysisfunction.civilservice.gov.uk/government-statistical-service-and-statistician-group/gss-support/methodology/information-on-specific-methods/) (i.e. not to the header within the page). 
