### PR TITLE
spp-7707 change internal methods line

### DIFF
--- a/sml_builder/templates/methods.html
+++ b/sml_builder/templates/methods.html
@@ -12,7 +12,7 @@
   <p>Codes and specification permission</p>
   <ul>
     <li>Public methods can be accessed freely by everyone</li>
-    <li>Internal methods’ access can be requested by ONS employees via their ONS Digital GitHub account</li>
+    <li>Internal methods can be accessed on request by ONS employees via their ONS Digital GitHub account</li>
     <li>Private methods can only be accessed upon request based on proposed usage</li>
   </ul>
 {% endcall %}


### PR DESCRIPTION
Description:

This story is about changing internal methods line as follows:

On: https://d1jgbw8ee9pybj.cloudfront.net/methods, in the grey box describing private/internal/public methods, change

Internal methods’ access can be requested by ONS employees via their ONS Digital GitHub account

TO

Internal methods can be accessed on request by ONS employees via their ONS Digital GitHub account

(Reason for this change: poor grammar/use of apostrophe, wording brings sentence in line with other lines in box)