### PR TITLE
HT/Ratio method name updated

### DIFF
--- a/content/methods/ht-ratio-estimation.jsonnet
+++ b/content/methods/ht-ratio-estimation.jsonnet
@@ -1,5 +1,5 @@
 {
-  title: 'HT/Ratio Estimation',
+  title: 'Horvitz-Thompson Ratio Estimator',
   date: '2022-05-18',
   contact_details: 'smlhelp@ons.gov.uk',
   method_metadata: {


### PR DESCRIPTION
https://jira.ons.gov.uk/browse/SPP-8331

Name of HT/ratio estimation renamed to Horvitz-Thompson Ratio Estimator

Signed-off-by: jasonbellONS <jason.bell@ons.gov.uk>