### PR TITLE
SPP-8252-upload-version-control-document

### DIFF
--- a/content/help_centre/version-methods.md
+++ b/content/help_centre/version-methods.md
@@ -11,3 +11,5 @@ The patch release version is incremented when backward compatible bugfixes are i
 Consult the [SML python/pySpark release history in Github](https://github.com/ONSdigital/statistical-methods-library/releases) for the current and past releases for the python/pySpark methods and the [associated python/pySpark release notes](https://github.com/ONSdigital/statistical-methods-library/tree/main/docs/release-notes) to understand the changes between releases.
 
 Consult the [SML python/pandas release history in Github](https://github.com/ONSdigital/sml-python-small/releases) for the current and past releases for the python/pandas methods and the [associated python/pandas release notes](https://github.com/ONSdigital/sml-python-small/tree/main/docs/release-notes) to understand the changes between releases.
+
+For further information about semantic versioning read the recommended [guidance](https://semver.org).


### PR DESCRIPTION
The ticket SPP-8252 was set up to add version control policy info to the sml catalogue help center. This was merged but requires the semver link to be added.

This PR is to cover adding the link to the version guidance.