### PR TITLE
SPP-8363 Update Privacy page to reference the correct URL

### DIFF
--- a/sml_builder/templates/content/privacy.html
+++ b/sml_builder/templates/content/privacy.html
@@ -32,9 +32,9 @@
 
 <p>If you go to another website from this one, read the privacy policy on that website to find out what it does with your information.</p>
 
-<h3>Following a link to sml.ons.gov.uk from another website</h3>
+<h3>Following a link to statisticalmethodslibrary.ons.gov.uk from another website</h3>
 
-<p>If you come to sml.ons.gov.uk from another website, we may receive personal information from the other website.</p>
+<p>If you come to statisticalmethodslibrary.ons.gov.uk from another website, we may receive personal information from the other website.</p>
 
 <p>You should read the privacy policy of the website you came from to find out more about this.</p>
 


### PR DESCRIPTION
Updating the Privacy Page to reference the correct URL

This was noticed during a review of the website content

Associated ticket: [SPP-8363](https://jira.ons.gov.uk/browse/SPP-8363)
