### PR TITLE
SPP-8455-add-back-link-to-help-centre

### DIFF
--- a/features/help_center.feature
+++ b/features/help_center.feature
@@ -6,9 +6,9 @@ Feature: Help center tests
         Given I'm an sml portal user trying to get to the help centre
         When I navigate to the help centre page
         Then The title of the help centre page is "Help centre"
-    
+
     Scenario: Content check for external user
-        Given I am on the how to submit a method request page
+        Given I'm an sml portal user on the "submit a method request"
         When I click the external user dropdown
         Then The drop down content is "Currently we do not accept formal method submissions or change requests from external users. In future, we will accept certain method requests via the Integrated Data Service https://integrateddataservice.gov.uk/. If you would like to make a suggestion for a new method, or to provide feedback about an existing method, please do so by emailing smlhelp@ons.gov.uk"
 
@@ -66,3 +66,13 @@ Feature: Help center tests
         Given I'm an sml portal user trying to get to the help centre
         When I navigate to the help centre page
         Then The subtitle of the help centre page is "Using GitHub"
+
+    Scenario: Back link check for sub categories
+        Given I'm an sml portal user on the "find and view methods page"
+        When I click the back link
+        Then The title of the help centre page is "Help centre"
+
+    Scenario: Back link check for submit a method request (uses different code to above test)
+        Given I'm an sml portal user on the "submit a method request"
+        When I click the back link
+        Then The title of the help centre page is "Help centre"

--- a/features/steps/help-centre.py
+++ b/features/steps/help-centre.py
@@ -13,40 +13,47 @@ host = setupSelenium.website_url
 def auth_user(context):
     driver.get(host)
 
-@given('I am on the how to submit a method request page')
-def auth_user(context):
-    driver.get(f"{host}help-centre/information/methods-request")
+@given('I\'m an sml portal user on the "{page}"')
+def auth_user(context, page):
+    if page == "find and view methods page":
+        driver.get(f"{host}help-centre/information/view-methods")
+    elif page == "submit a method request":
+        driver.get(f"{host}help-centre/information/methods-request")
 
 @when('I navigate to the help centre page')
 def navigate_to_url(context):
-     WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.LINK_TEXT, value='Help centre')).click()
-     WebDriverWait(driver, timeout=10).until(EC.presence_of_element_located((By.ID, 'main-content')))
+    WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.LINK_TEXT, value='Help centre')).click()
+    WebDriverWait(driver, timeout=10).until(EC.presence_of_element_located((By.ID, 'main-content')))
+
+@when('I click the back link')
+def navigate_to_url(context):
+    WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.ID, value='back')).click()
 
 @when('I click the external user dropdown')
 def navigate_to_url(context):
-     WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.ID, value='collapsibleONSExternalUserId')).click()
-     WebDriverWait(driver, timeout=10).until(EC.presence_of_element_located((By.ID, 'collapsibleONSExternalUserId-content')))
+    WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.ID, value='collapsibleONSExternalUserId')).click()
+    WebDriverWait(driver, timeout=10).until(EC.presence_of_element_located((By.ID, 'collapsibleONSExternalUserId-content')))
 
 @then('The title of the help centre page is "{title}"')
 def check_title(context, title):
-    page_title =  WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.TAG_NAME, value="h1")).text
+    page_title = WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.TAG_NAME, value="h1")).text
     assert page_title == title
 
 @then('The drop down content is "{text}"')
 def check_title(context, text):
-    content_div =  WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.ID, value='collapsibleONSExternalUserId-content'))
+    content_div = WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.ID, value='collapsibleONSExternalUserId-content'))
     dropdown_content_elements = content_div.find_elements(By.TAG_NAME, "p")
     dropdown_content = ""
 
-    for i in range (len(dropdown_content_elements)):
+    for i in range(len(dropdown_content_elements)):
         dropdown_content += dropdown_content_elements[i].text
         dropdown_content += " "
 
     dropdown_content = dropdown_content.replace('(opens in a new tab)', '').replace('\n', '').rstrip()
     print(dropdown_content)
     assert dropdown_content == text
-    
+
 @then('The subtitle of the help centre page is "{subtitle}"')
 def check_title(context, subtitle):
-    page_title =  WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.LINK_TEXT, subtitle)).text
+    page_title = WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.LINK_TEXT, subtitle)).text
     assert page_title == subtitle

--- a/sml_builder/templates/help-methods-request.html
+++ b/sml_builder/templates/help-methods-request.html
@@ -2,6 +2,17 @@
 {% from "components/section-navigation/_macro.njk" import onsSectionNavigation %}
 {% from "components/lists/_macro.njk" import onsList %}
 {% from "components/collapsible/_macro.njk" import onsCollapsible %}
+{%- set breadcrumbs = {
+  "id":"breadcrumbs",
+  "ariaLabel":"breadcrumbs",
+  "itemsList":[
+    {
+      "url": url_for("help_centre"),
+      "id": "back",
+      "text": 'Back',
+    }
+  ]
+} -%}
 
 {% import "related-content-macro.html" as macros %}
 

--- a/sml_builder/templates/help_category.html
+++ b/sml_builder/templates/help_category.html
@@ -1,6 +1,17 @@
 {%- extends "core.html" -%}
 {% from "components/section-navigation/_macro.njk" import onsSectionNavigation %}
 {% from "components/lists/_macro.njk" import onsList %}
+{%- set breadcrumbs = {
+  "id":"breadcrumbs",
+  "ariaLabel":"breadcrumbs",
+  "itemsList":[
+    {
+      "url": url_for("help_centre"),
+      "id": "back",
+      "text": 'Back',
+    }
+  ]
+} -%}
 
 {% import "related-content-macro.html" as macros %}
 


### PR DESCRIPTION
# Description

The help center sub categories do not have a back link present unlike the method summary pages. This ticket is to add them in.

Comments and documentation not updated due to self explanatory code

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical Enhancements


# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [x] Code review (informal/walkthrough (and/or produced with Pair programming)
- [x] Code review completed by the appropriate people (1 thumbs up)
- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance.

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] Functional test passed
- [x] Acceptance criteria met

**Deployment**

- [x] Builds are green

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] Up to date with the main branch