### PR TITLE
SPP-8526-Move-View-Methods-To-Access-Section

### DIFF
--- a/content/help_centre/help_centre.json
+++ b/content/help_centre/help_centre.json
@@ -4,10 +4,7 @@
             "name": "information",
             "label": "Information",
             "subcategories": [
-                {
-                    "name": "view-methods",
-                    "label": "Find and view methods"
-                },
+
                 {
                     "name": "methods-request",
                     "label": "Submit a method request"
@@ -26,6 +23,10 @@
             "name": "access",
             "label": "Access (and usage)",
             "subcategories": [
+                {
+                    "name": "view-methods",
+                    "label": "Find and view methods"
+                },
                 {
                     "name": "run-a-method",
                     "label": "Use a method"

--- a/features/steps/help-centre.py
+++ b/features/steps/help-centre.py
@@ -17,7 +17,7 @@ def auth_user(context):
 @given('I\'m an sml portal user on the "{page}"')
 def auth_user(context, page):
     if page == "find and view methods page":
-        driver.get(f"{host}help-centre/information/view-methods")
+        driver.get(f"{host}help-centre/access/view-methods")
     elif page == "submit a method request":
         driver.get(f"{host}help-centre/information/methods-request")
 

--- a/features/steps/setupSelenium.py
+++ b/features/steps/setupSelenium.py
@@ -3,5 +3,5 @@ from selenium.webdriver.chrome.options import Options
 options = Options()
 options.headless = True
 driver = webdriver.Chrome(options=options)
-website_url = "http://127.0.0.1:5000/"
+website_url = "http://localhost:8000/"
 timeout = 5

--- a/features/steps/setupSelenium.py
+++ b/features/steps/setupSelenium.py
@@ -3,5 +3,5 @@ from selenium.webdriver.chrome.options import Options
 options = Options()
 options.headless = True
 driver = webdriver.Chrome(options=options)
-website_url = "http://localhost:8000/"
+website_url = "http://127.0.0.1:5000/"
 timeout = 5


### PR DESCRIPTION
Find and view methods link moved to access (and usage) section of the help center (originally was in information section at top of page). Behave tests amended in-line with this change



Signed-off-by: jasonbellONS <jason.bell@ons.gov.uk>