### PR TITLE
Amending Destroy scripts to correctly destroy environment, amending main workspace name for bucket update

### DIFF
--- a/ci/dev-pipeline.yml
+++ b/ci/dev-pipeline.yml
@@ -177,6 +177,7 @@ jobs:
               <<: *sml_dev_setup
               TERRAFORM_SOURCE: repo/terraform
               WORKSPACE_KEY_INFIX: workspace
+              TF_WORKSPACE: main
 
           - task: build-files
             file: repo/ci/tasks/build_and_deploy/build_files.yml
@@ -203,6 +204,7 @@ jobs:
               <<: *sml_preprod_setup
               TERRAFORM_SOURCE: repo/terraform
               WORKSPACE_KEY_INFIX: workspace
+              TF_WORKSPACE: main
 
           - task: build-files
             file: repo/ci/tasks/build_and_deploy/build_files.yml
@@ -229,6 +231,7 @@ jobs:
                   <<: *sml_prod_setup
                   TERRAFORM_SOURCE: repo/terraform
                   WORKSPACE_KEY_INFIX: workspace
+                  TF_WORKSPACE: main
 
               - task: build-files
                 file: repo/ci/tasks/build_and_deploy/build_files.yml

--- a/ci/dev-pipeline.yml
+++ b/ci/dev-pipeline.yml
@@ -265,7 +265,7 @@ jobs:
             file: repo/ci/tasks/terraform/destroy_terraform.yml
             params:
               <<: *sml_dev_setup
-
+              WORKSPACE_KEY_INFIX: workspace
     on_success:
       put: repo
       resource: pr-done

--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -270,6 +270,7 @@ jobs:
             file: repo/ci/tasks/terraform/destroy_terraform.yml
             params:
               <<: *sml_dev_setup
+              WORKSPACE_KEY_INFIX: workspace
     on_success:
       put: repo
       resource: pr-done

--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -237,7 +237,6 @@ jobs:
                   WORKSPACE_KEY_INFIX: workspace
                   TF_WORKSPACE: main
 
-
               - task: build-files
                 file: repo/ci/tasks/build_and_deploy/build_files.yml
 

--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -181,6 +181,7 @@ jobs:
                   <<: *sml_dev_setup
                   TERRAFORM_SOURCE: repo/terraform
                   WORKSPACE_KEY_INFIX: workspace
+                  TF_WORKSPACE: main
 
               - task: build-files
                 file: repo/ci/tasks/build_and_deploy/build_files.yml
@@ -193,6 +194,7 @@ jobs:
 
           - task: run-acceptance-tests
             file: repo/ci/tasks/testing/run_bdd_tests.yml
+
   - name: build_and_deploy_preprod
     plan:
       - do:
@@ -206,6 +208,7 @@ jobs:
               <<: *sml_preprod_setup
               TERRAFORM_SOURCE: repo/terraform
               WORKSPACE_KEY_INFIX: workspace
+              TF_WORKSPACE: main
 
           - task: build-files
             file: repo/ci/tasks/build_and_deploy/build_files.yml
@@ -232,6 +235,7 @@ jobs:
                   <<: *sml_prod_setup
                   TERRAFORM_SOURCE: repo/terraform
                   WORKSPACE_KEY_INFIX: workspace
+                  TF_WORKSPACE: main
 
               - task: build-files
                 file: repo/ci/tasks/build_and_deploy/build_files.yml

--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -237,6 +237,7 @@ jobs:
                   WORKSPACE_KEY_INFIX: workspace
                   TF_WORKSPACE: main
 
+
               - task: build-files
                 file: repo/ci/tasks/build_and_deploy/build_files.yml
 

--- a/ci/tasks/terraform/apply_terraform.sh
+++ b/ci/tasks/terraform/apply_terraform.sh
@@ -25,7 +25,7 @@ terraform init \
     -backend-config "key=${S3_KEY}" \
     -backend-config "workspace_key_prefix=${WORKSPACE_KEY_INFIX}"
 echo "starting terraform plan"
-export TF_WORKSPACE=`cat ../.git/resource/head_name| tr "[:upper:]" "[:lower:]"`
+if [ -z ${TF_WORKSPACE+x} ]; then export TF_WORKSPACE=`cat ../.git/resource/head_name | tr "[:upper:]" "[:lower:]"`; else echo "Workspace already set"; fi
 echo Workspace: ${TF_WORKSPACE}
 terraform plan -out=plan.tfstate
 echo "starting terraform apply"

--- a/ci/tasks/terraform/apply_terraform.yml
+++ b/ci/tasks/terraform/apply_terraform.yml
@@ -19,4 +19,4 @@ run:
     - -exc
     - |
       apk add --update --no-progress bash jq
-      bash ./repo/ci/tasks/terraform/apply_terraform.sh
+      bash ./ci/tasks/terraform/apply_terraform.sh

--- a/ci/tasks/terraform/apply_terraform.yml
+++ b/ci/tasks/terraform/apply_terraform.yml
@@ -19,4 +19,4 @@ run:
     - -exc
     - |
       apk add --update --no-progress bash jq
-      bash ./ci/tasks/terraform/apply_terraform.sh
+      bash ./repo/ci/tasks/terraform/apply_terraform.sh

--- a/ci/tasks/terraform/destroy_terraform.sh
+++ b/ci/tasks/terraform/destroy_terraform.sh
@@ -19,7 +19,7 @@ export TF_VAR_head_sha_short=$(cat .git/resource/head_sha_short)
 
 # --------------------------
 
-cd terraform/environment
+cd terraform
 
 terraform init \
 -upgrade \

--- a/ci/tasks/terraform/destroy_terraform.sh
+++ b/ci/tasks/terraform/destroy_terraform.sh
@@ -35,6 +35,3 @@ echo "Workspace: ${TF_WORKSPACE}"
 # --------------------------
 
 terraform destroy -auto-approve
-
-export TF_WORKSPACE=""
-terraform workspace delete "$(cat ../../.workspace)" || ( echo "ERROR: Could not delete workspace!" && exit 1)

--- a/ci/tasks/terraform/destroy_terraform.sh
+++ b/ci/tasks/terraform/destroy_terraform.sh
@@ -29,7 +29,7 @@ terraform init \
 
 # --------------------------
 
-export TF_WORKSPACE=$(cat ~/repo/.workspace)
+export TF_WORKSPACE=`cat ../.git/resource/head_name | tr "[:upper:]" "[:lower:]"`
 echo "Workspace: ${TF_WORKSPACE}"
 
 # --------------------------

--- a/ci/tasks/terraform/destroy_terraform.yml
+++ b/ci/tasks/terraform/destroy_terraform.yml
@@ -17,4 +17,5 @@ run:
   args:
     - -exc
     - |
+      apk add --update --no-progress bash jq
       bash ./ci/tasks/terraform/destroy_terraform.sh

--- a/ci/tasks/terraform/destroy_terraform.yml
+++ b/ci/tasks/terraform/destroy_terraform.yml
@@ -12,9 +12,8 @@ inputs:
 
 run:
   path: sh
-  dir: repo
   args:
     - -exc
     - |
       apk add --update --no-progress bash jq
-      bash ./ci/tasks/terraform/destroy_terraform.sh
+      bash ./repo/ci/tasks/terraform/destroy_terraform.sh

--- a/ci/tasks/terraform/destroy_terraform.yml
+++ b/ci/tasks/terraform/destroy_terraform.yml
@@ -12,4 +12,9 @@ inputs:
   - name: json-identities
 
 run:
-  path: repo/ci/tasks/terraform/destroy_terraform.sh
+  path: sh
+  dir: repo
+  args:
+    - -exc
+    - |
+      bash ./ci/tasks/terraform/destroy_terraform.sh

--- a/ci/tasks/terraform/destroy_terraform.yml
+++ b/ci/tasks/terraform/destroy_terraform.yml
@@ -9,7 +9,6 @@ image_resource:
 
 inputs:
   - name: repo
-  - name: json-identities
 
 run:
   path: sh

--- a/ci/tasks/terraform/init_metadata.yml
+++ b/ci/tasks/terraform/init_metadata.yml
@@ -19,9 +19,8 @@ outputs:
 
 run:
   path: sh
-  dir: repo
   args:
     - -exc
     - |
       apk add --update --no-progress bash jq
-      bash ./ci/tasks/terraform/init_metadata.sh
+      bash ./repo/ci/tasks/terraform/init_metadata.sh

--- a/ci/tasks/terraform/init_metadata.yml
+++ b/ci/tasks/terraform/init_metadata.yml
@@ -18,4 +18,9 @@ outputs:
   - name: repo
 
 run:
-  path: repo/ci/tasks/terraform/init_metadata.sh
+  path: sh
+  dir: repo
+  args:
+    - -exc
+    - | 
+      bash ./ci/tasks/terraform/init_metadata.sh

--- a/ci/tasks/terraform/init_metadata.yml
+++ b/ci/tasks/terraform/init_metadata.yml
@@ -8,8 +8,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: public.ecr.aws/docker/library/alpine
-    tag: latest
+    repository: public.ecr.aws/ons-spp/concourse-init-metadata
+    tag: 1
 
 inputs:
   - name: repo
@@ -22,5 +22,6 @@ run:
   dir: repo
   args:
     - -exc
-    - | 
+    - |
+      apk add --update --no-progress bash jq
       bash ./ci/tasks/terraform/init_metadata.sh


### PR DESCRIPTION
Amendments to concourse destroy pipeline to correctly destroy s3 bucket on merge/close of pr. Main pipelines amended to correctly get Main as their branch, rather than appending default and creating a new bucket