### PR TITLE
SPP-9387-semantic-release-fix

### DIFF
--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -229,6 +229,8 @@ jobs:
           - task: build-files
             file: repo/ci/tasks/build_and_deploy/build_files.yml
             params:
+              <<: *github_pull_creds
+              <<: *sml_preprod_setup
               BUILD_TYPE: 1
               GH_TOKEN: ((github_access_token))
 

--- a/ci/tasks/build_and_deploy/build_files.sh
+++ b/ci/tasks/build_and_deploy/build_files.sh
@@ -30,6 +30,8 @@ if [ "$BUILD_TYPE" -eq 0 ]; then
   run_linting
   python freeze.py
 elif [ "$BUILD_TYPE" -eq 1 ]; then
+  git config --global user.email "spp-shared-services@example.com"
+  git config --global user.name "spp-shared-services"
   git fetch
   run_linting
   semantic-release publish --prerelease


### PR DESCRIPTION
Fix: adding in git credentials to the pipeline as the basic git resource doesn't set these, whereas the PR resource did