### PR TITLE
ci: adding in  commit verification keys for signed commits

### DIFF
--- a/ci/dev-pipeline.yml
+++ b/ci/dev-pipeline.yml
@@ -75,6 +75,7 @@ resources:
       tag: ((RELEASE_CANDIDATE))
       username: ((github_access_token))
       password: x-oauth-basic
+      commit_verification_keys: ((github_ons_spp_machine_user_gpg_key_private)
   - name: main
     type: git
     icon: github
@@ -85,6 +86,7 @@ resources:
       branch: main
       username: ((github_access_token))
       password: x-oauth-basic
+      commit_verification_keys: ((github_ons_spp_machine_user_gpg_key_private)
   - name: main-updated
     type: git
     icon: github

--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -27,6 +27,7 @@ env_setups:
   github_pull_creds: &github_pull_creds
     username: ((github_access_token))
     password: x-oauth-basic
+    
 
   # -------------------
 
@@ -75,6 +76,7 @@ resources:
       tag: ((RELEASE_CANDIDATE))
       username: ((github_access_token))
       password: x-oauth-basic
+      commit_verification_keys: ((github_ons_spp_machine_user_gpg_key_private))
   - name: main
     type: git
     icon: github
@@ -85,6 +87,7 @@ resources:
       branch: main
       username: ((github_access_token))
       password: x-oauth-basic
+      commit_verification_keys: ((github_ons_spp_machine_user_gpg_key_private))
   - name: main-updated
     type: git
     icon: github


### PR DESCRIPTION
CI fix to add in the new gpg verification key for signed commits from the concourse pipeline to allow semantic release automation

If you have not checked any of the lists below explain why here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [x] Code to be commented on where applicable 
- [x] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
