### PR TITLE
SPP-9446-rename-duplicate-page-titles

### DIFF
--- a/features/accessibility.feature
+++ b/features/accessibility.feature
@@ -11,67 +11,67 @@ Feature: About library tests
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "submit a method request" page
-        Then The title of the help centre page is "Submit a method request"
+        Then The title of the page is "Help centre - Submit a method request"
         And The accessibility test passes
 
     Scenario: Submit a method request page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "how the methods are versioned" page
-        Then The title of the help centre page is "How the methods are versioned"
+        Then The title of the page is "Help centre - How the methods are versioned"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "coding standards" page
-        Then The title of the help centre page is "Coding standards"
+        Then The title of the page is "Help centre - Coding standards"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "find and view methods" page
-        Then The title of the help centre page is "Find and view methods"
+        Then The title of the page is "Help centre - Find and view methods"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "use a method" page
-        Then The title of the help centre page is "Use a method"
+        Then The title of the page is "Help centre - Use a method"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "report a defect or bug" page
-        Then The title of the help centre page is "Report a defect or bug"
+        Then The title of the page is "Help centre - Report a defect or bug"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "provide feedback" page
-        Then The title of the help centre page is "Provide feedback"
+        Then The title of the page is "Help centre - Provide feedback"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "get support" page
-        Then The title of the help centre page is "Get support"
+        Then The title of the page is "Help centre - Get support"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "get information on expert groups" page
-        Then The title of the help centre page is "Get information on expert groups"
+        Then The title of the page is "Help centre - Get information on expert groups"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "troubleshooting" page
-        Then The title of the help centre page is "Troubleshooting"
+        Then The title of the page is "Help centre - Troubleshooting"
         And The accessibility test passes
 
     Scenario: Help centre page accessibility check
         Given I'm an sml portal user
         When I navigate to the help centre "using github" page
-        Then The title of the help centre page is "Using GitHub"
+        Then The title of the page is "Help centre - Using GitHub"
         And The accessibility test passes
 
     Scenario: Accessibility page accessibility check

--- a/features/help_center.feature
+++ b/features/help_center.feature
@@ -79,10 +79,10 @@ Feature: Help center tests
 
     Scenario: Back link check for sub categories
         Given I'm an sml portal user on the "find and view methods" page
-        When I click the "back" link
+        When I click the "Back" link
         Then The title of the page is "Help centre"
 
     Scenario: Back link check for submit a method request (uses different code to above test)
         Given I'm an sml portal user on the "submit a method request" page
-        When I click the "back" link
+        When I click the "Back" link
         Then The title of the page is "Help centre"

--- a/features/steps/generic.py
+++ b/features/steps/generic.py
@@ -34,12 +34,6 @@ def check_title(context, title):
     page_title = WebDriverWait(driver, timeout=timeout).until(lambda d: d.find_element(By.TAG_NAME, "h1")).text
     assert page_title == title
 
-@then('The title of the help centre page is "{title}"')
-def check_title(context, title):
-    page_title = WebDriverWait(driver, timeout=timeout).until(lambda d: d.find_element(By.TAG_NAME, "h3")).text
-    assert page_title == title
-
-
 @then('The subtitle of the page is "{subtitle}"')
 def check_subtitle(context, subtitle):
     page_subtitle = WebDriverWait(driver, timeout=10).until(lambda d: d.find_element(By.ID, "page-subtitle")).text

--- a/sml_builder/templates/help-methods-request.html
+++ b/sml_builder/templates/help-methods-request.html
@@ -16,7 +16,7 @@
 } -%}
 
 {% import "related-content-macro.html" as macros %}
-{%- set page_title = "Help centre" -%}
+{%- set page_title = "Help centre - "~sub_category_label -%}
 {%- set current_path = url_for("help_centre") -%}
 {%- block mainContent -%}
 

--- a/sml_builder/templates/help-methods-request.html
+++ b/sml_builder/templates/help-methods-request.html
@@ -20,9 +20,8 @@
 {%- set current_path = url_for("help_centre") -%}
 {%- block mainContent -%}
 
-              <h1>Help centre</h1>
+              <h1>Help centre - {{sub_category_label}}</h1>
                 <h2>{{category_label}}</h2>
-                <h3>{{sub_category_label}}</h3>
 
             {% call onsDetails({
                   "id": "collapsibleONSInternalUserId",

--- a/sml_builder/templates/help_category.html
+++ b/sml_builder/templates/help_category.html
@@ -19,9 +19,8 @@
 {%- set page_title = "Help centre" -%}
 {%- set current_path = url_for("help_centre") -%}
 {%- block mainContent -%}
-  <h1>Help centre</h1>
+  <h1>Help centre - {{sub_category_label}}</h1>
     <h2>{{category_label}}</h2>
-    <h3>{{sub_category_label}}</h3>
     {%if sub_category == "expert-groups" %}
       <p> Please visit
         {% from "components/external-link/_macro.njk" import onsExternalLink %}

--- a/sml_builder/templates/help_category.html
+++ b/sml_builder/templates/help_category.html
@@ -16,7 +16,7 @@
 {% import "related-content-macro.html" as macros %}
 
 {% set sidebarCols = 7 %}
-{%- set page_title = "Help centre" -%}
+{%- set page_title = "Help centre - "~sub_category_label -%}
 {%- set current_path = url_for("help_centre") -%}
 {%- block mainContent -%}
   <h1>Help centre - {{sub_category_label}}</h1>


### PR DESCRIPTION
# Description

This pull request is to amend the duplicated page titles and headings across multiple pages in the help centre. This will make it easier for screen reader users to distinguish between each of the pages.

Code has not been commented and documentation has not been written because it is not necessary for this pull request.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
