### PR TITLE
SPP-9996 Concourse Pipeline False Pass Fix

### DIFF
--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -170,15 +170,17 @@ jobs:
         status: success
         context: Deploying_Dev
         comment_file: GITHUB_OUTPUT/output.txt
+        delete_previous_comments: true
 
     on_failure:
       put: repo
       resource: pr-open
       params:
         path: repo
-        status: success
+        status: failure
         context: Deploying_Dev
         comment_file: GITHUB_OUTPUT/output.txt
+        delete_previous_comments: true
 
   - name: build_and_deploy_dev
     plan:

--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -316,5 +316,5 @@ jobs:
       resource: pr-done
       params:
         path: repo
-        status: success
+        status: failure
         context: Deleting Workspace

--- a/ci/tasks/testing/run_bdd_tests.sh
+++ b/ci/tasks/testing/run_bdd_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Runs BDD testing on the deployed workspace
 

--- a/ci/tasks/testing/run_bdd_tests.sh
+++ b/ci/tasks/testing/run_bdd_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo
 
 # Runs BDD testing on the deployed workspace
 

--- a/ci/tasks/testing/run_bdd_tests.sh
+++ b/ci/tasks/testing/run_bdd_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo
+set -euo pipefail
 
 # Runs BDD testing on the deployed workspace
 

--- a/ci/tasks/testing/run_bdd_tests.sh
+++ b/ci/tasks/testing/run_bdd_tests.sh
@@ -5,7 +5,6 @@ set -euo
 
 : ${URL}
 
-cd repo
 pip install poetry
 poetry install --sync
 echo "Check if project toml file and poetry lock file are in sync"

--- a/features/methods.feature
+++ b/features/methods.feature
@@ -60,5 +60,5 @@ Feature: Methods catalogue tests
     Scenario: Selective editing table row check
         Given I'm an sml portal user trying to get to the methods catalogue page
         When I navigate to the methods catalogue page
-        Then The "ready" table row of the method are "Selectiveee Editing" "Editing" "Editing & Imputation" "Python/Pandas"
+        Then The "ready" table row of the method are "Selective Editing" "Editing" "Editing & Imputation" "Python/Pandas"
 

--- a/features/methods.feature
+++ b/features/methods.feature
@@ -60,5 +60,5 @@ Feature: Methods catalogue tests
     Scenario: Selective editing table row check
         Given I'm an sml portal user trying to get to the methods catalogue page
         When I navigate to the methods catalogue page
-        Then The "ready" table row of the method are "Selective Editing" "Editing" "Editing & Imputation" "Python/Pandas"
+        Then The "ready" table row of the method are "Selectivee Editing" "Editing" "Editing & Imputation" "Python/Pandas"
 

--- a/features/methods.feature
+++ b/features/methods.feature
@@ -60,5 +60,5 @@ Feature: Methods catalogue tests
     Scenario: Selective editing table row check
         Given I'm an sml portal user trying to get to the methods catalogue page
         When I navigate to the methods catalogue page
-        Then The "ready" table row of the method are "Selectivee Editing" "Editing" "Editing & Imputation" "Python/Pandas"
+        Then The "ready" table row of the method are "Selectiveee Editing" "Editing" "Editing & Imputation" "Python/Pandas"
 


### PR DESCRIPTION
# Description

When running the BDD tests for the sml-catalogue repo, and the tests fail in the concourse pipeline, GitHub checks still pass and let you merge the dev branch to the main.

run_bdd_tests.sh file updated to fix this issue.

Documentation & code comments are not necessary in this instance.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
