### PR TITLE
SPP-10170-break-up-box-of-test

### DIFF
--- a/features/help_center.feature
+++ b/features/help_center.feature
@@ -10,7 +10,7 @@ Feature: Help center tests
     Scenario: Content check for external user
         Given I'm an sml portal user on the "submit a method request" page
         When I click the external user dropdown
-        Then The drop down content is "Currently we do not accept formal method submissions or change requests from external users. In future, we will accept certain method requests via the Integrated Data Service https://integrateddataservice.gov.uk/. If you would like to make a suggestion for a new method, or to provide feedback about an existing method, please do so by emailing smlhelp@ons.gov.uk"
+        Then The drop down content is "Currently we do not accept formal method submissions or change requests from external users. In future, we will accept certain method requests via the Integrated Data Service https://integrateddataservice.gov.uk/. If you would like to make a suggestion for a new method, or to provide feedback about an existing method, please do so by emailing smlhelp@ons.gov.uk."
 
     Scenario: Sub-title check for find and view methods
         Given I'm an sml portal user trying to get to the help centre

--- a/sml_builder/templates/help-methods-request.html
+++ b/sml_builder/templates/help-methods-request.html
@@ -106,7 +106,7 @@
                                 "url": 'mailto:smlhelp@ons.gov.uk',
                                 "linkText": 'smlhelp@ons.gov.uk'
                                 })
-                            }}
+                            }}.
                 </p>
 
             {% endcall %}

--- a/sml_builder/templates/help-methods-request.html
+++ b/sml_builder/templates/help-methods-request.html
@@ -96,7 +96,9 @@
                                 "url": 'https://integrateddataservice.gov.uk/',
                                 "linkText": 'https://integrateddataservice.gov.uk/'
                                 })
-                            }}. If you would like to make a suggestion
+                            }}. 
+                </p>
+                <p>If you would like to make a suggestion
                     for a new method, or to provide feedback about an existing method, please do so by emailing
                     {% from "components/external-link/_macro.njk" import onsExternalLink %}
                             {{


### PR DESCRIPTION
# Description

The text on the drop down 'I am a user from outside the ONS' on the help center method request page, is difficult to read as the blocks of text don't start on separate lines, this PR will break up the blocks of text.

No comments or documentation  added as it wasn't needed for this specific PR

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [X] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [X] I have linted the code

**Testing**

- [X] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [X] I have run the behave command to check the selenium behaviour tests pass locally
- [X] Acceptance criteria met

**Other Checks**
- [X] I have performed a self-review of my own code
- [X] I have checked for spelling errors
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes don't break anything unexpected
- [X] I have checked and updated the security.txt file where required
- [X] Up to date with the main branch
