### PR TITLE
SPP-9540-amend-focus-order

### DIFF
--- a/sml_builder/templates/glossary.html
+++ b/sml_builder/templates/glossary.html
@@ -8,18 +8,6 @@
 
 {%- block main -%}
 
-    {%- from "components/button/_macro.njk" import onsButton -%}
-    {{
-        onsButton({
-            "text": 'Back to top',
-            "title": 'Go to top',
-            "id": 'topBtn',
-            "url": "#",
-            "iconType": 'arrow-next',
-            "variants": ['secondary']
-        })
-    }}
-
     <h1 class="ons-u-mt-no">Library glossary</h1>
 
     <p id="page-subtitle">Definitions of words, phrases, and abbreviations used within the Statistical Methods Library</p>
@@ -77,6 +65,18 @@
 
         <hr>
     {%- endfor -%}
+
+    {%- from "components/button/_macro.njk" import onsButton -%}
+    {{
+        onsButton({
+            "text": 'Back to top',
+            "title": 'Go to top',
+            "id": 'topBtn',
+            "url": "#",
+            "iconType": 'arrow-next',
+            "variants": ['secondary']
+        })
+    }}
 
 {% endblock main -%}
 


### PR DESCRIPTION
# Description

When users activate the ‘Skip to main content’ link the focus shift to the main content as expected but if the users continue to navigate using the tab key, focus is placed on the ‘Back to top’ button and then to the alphabetical links inside the main content. This creates an illogical focus order and may be problematic for keyboard only and screen reader users.

This PR will ensure that the 'Back to top' button is correctly positioned so that the page has a logical focus order.

Code has not been commented and documentation has not been provided because it is not necessary for this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
