### PR TITLE
SPP-10242-update-catalogue-pytools-file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ werkzeug = "2.3.7"
 [tool.bandit]
 exclude_dirs = ["features", "./venv/"]
 
+[tool.isort]
+profile="black"
+known_third_party=["boto3","moto","pandas","numpy"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# Description

Part of [SPP-10242's pull request](https://github.com/ONSdigital/sml-python-small/pull/67).

This PR fixes an compatibility issue between black and isort by ensuring that isort uses the 'black' profile.

Code has not been commented and documentation has not been provided since it is not necessary for this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
