### PR TITLE
docs: amending pr template to show required tags

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,19 +38,18 @@ If any of these are not completed, please explain why in the notes.
 - [ ] My changes don't break anything unexpected
 - [ ] I have checked and updated the security.txt file where required
 - [ ] Up to date with the main branch
-- [ ] I have a commit with the fix:, feat or BREAKING_CHANGE: tags (or other relevant tag) and will copy this commit message to the squash
-commit message
+- [ ] For a change that needs to be deployed in a release I have a commit with the fix:, feat: or BREAKING CHANGE:
+tags and will copy this commit message to the squash
+- [ ] For a change that does not affect the deployed code I have added a commit with ci:, docs: or test:
+depending upon which area of the solution was affected
 
 Note when merging, squash commit must begin with one of the following tags:
-"BREAKING CHANGE", "feat", "fix", "perf", "build", "chore", "ci", "docs", "style", "refactor", "test"
+"BREAKING CHANGE", "feat", "fix", "ci", "docs", "test"
 
 Usage
 
-build: Changes that affect the build system or external dependencies (e.g Pyproject)
-
-ci: Changes to our CI configuration files and scripts (Concourse)
-
-docs: Documentation only changes
+BREAKING CHANGE: any change that breaks current functionality and may cause compatibility errors to users upgrading
+    E.G BREAKING CHANGE: refactored method x to take variable y as input (changed from variable z)
 
 feat: A new feature
     E.G feat: adding method x to future methods table
@@ -58,16 +57,8 @@ feat: A new feature
 fix: A bug fix
     E.G fix: amending page for method x to show correct release version
 
-perf: A code change that improves performance
-    E.G perf: amending issue on page x which impacted load times
+ci: Changes to our CI configuration files and scripts (Concourse)
 
-BREAKING CHANGE: any change that breaks current functionality and may cause compatibility errors to users upgrading
-    E.G BREAKING CHANGE: refactored method x to take variable y as input (changed from variable z)
-
-refactor: A code change that neither fixes a bug nor adds a feature
+docs: Documentation only changes
 
 test: Adding missing tests or correcting existing tests
-
-chore: A task that has to be done on a regular basis that may or may not be automated, (E.G AXE test reports)
-
-style: A change to amend code styling (black, pylint, flake8)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,3 +43,31 @@ commit message
 
 Note when merging, squash commit must begin with one of the following tags:
 "BREAKING CHANGE", "feat", "fix", "perf", "build", "chore", "ci", "docs", "style", "refactor", "test"
+
+Usage
+
+build: Changes that affect the build system or external dependencies (e.g Pyproject)
+
+ci: Changes to our CI configuration files and scripts (Concourse)
+
+docs: Documentation only changes
+
+feat: A new feature
+    E.G feat: adding method x to future methods table
+
+fix: A bug fix
+    E.G fix: amending page for method x to show correct release version
+
+perf: A code change that improves performance
+    E.G perf: amending issue on page x which impacted load times
+
+BREAKING CHANGE: any change that breaks current functionality and may cause compatibility errors to users upgrading
+    E.G BREAKING CHANGE: refactored method x to take variable y as input (changed from variable z)
+
+refactor: A code change that neither fixes a bug nor adds a feature
+
+test: Adding missing tests or correcting existing tests
+
+chore: A task that has to be done on a regular basis that may or may not be automated, (E.G AXE test reports)
+
+style: A change to amend code styling (black, pylint, flake8)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,3 +40,6 @@ If any of these are not completed, please explain why in the notes.
 - [ ] Up to date with the main branch
 - [ ] I have a commit with the fix:, feat or BREAKING_CHANGE: tags and will copy this commit message to the squash
 commit message
+
+Note when merging, squash commit must begin with one of the following tags:
+"BREAKING CHANGE", "feat", "fix", "perf", "build", "chore", "ci", "docs", "style", "refactor", "test"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@ If any of these are not completed, please explain why in the notes.
 - [ ] My changes don't break anything unexpected
 - [ ] I have checked and updated the security.txt file where required
 - [ ] Up to date with the main branch
-- [ ] I have a commit with the fix:, feat or BREAKING_CHANGE: tags and will copy this commit message to the squash
+- [ ] I have a commit with the fix:, feat or BREAKING_CHANGE: tags (or other relevant tag) and will copy this commit message to the squash
 commit message
 
 Note when merging, squash commit must begin with one of the following tags:


### PR DESCRIPTION
# Description

Rule changes added to require one of the semantic versioning tags in order to complete a pr, amendments to the PR template to remind users of these tags

If you have not checked any of the lists below explain why here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [x] Code to be commented on where applicable 
- [x] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
- [x] I have a commit with the fix:, feat or BREAKING_CHANGE: tags and will copy this commit message to the squash
commit message
