### PR TITLE
SPP-10758 Invalidate Cloudfront Cache During Deployment 

### DIFF
--- a/ci/tasks/build_and_deploy/deploy.sh
+++ b/ci/tasks/build_and_deploy/deploy.sh
@@ -16,7 +16,7 @@ aws sts assume-role --output text \
 export AWS_ACCESS_KEY_ID="$(cat AccessKeyId)"
 export AWS_SECRET_ACCESS_KEY="$(cat SecretAccessKey)"
 export AWS_SESSION_TOKEN="$(cat SessionToken)"
-export TF_DIST_ID=$(sed -n 2p ../GITHUB_OUTPUT/output.txt && cut -c 15-)
+export TF_DIST_ID=$(sed -n "2p" ../GITHUB_OUTPUT/output.txt | cut -c 15-)
 
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --content-type "text/html" --exclude "*.css" --exclude "*.js"
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --exclude "*" --include "*.css" --include "*.js"

--- a/ci/tasks/build_and_deploy/deploy.sh
+++ b/ci/tasks/build_and_deploy/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Deploys build code to the s3 bucket
+# Cloudfront cache is also invalidated to refresh website instance
 
 set -euo pipefail
 

--- a/ci/tasks/build_and_deploy/deploy.sh
+++ b/ci/tasks/build_and_deploy/deploy.sh
@@ -16,7 +16,7 @@ aws sts assume-role --output text \
 export AWS_ACCESS_KEY_ID="$(cat AccessKeyId)"
 export AWS_SECRET_ACCESS_KEY="$(cat SecretAccessKey)"
 export AWS_SESSION_TOKEN="$(cat SessionToken)"
-export TF_DIST_ID=sed -n "${2}p" ../GITHUB_OUTPUT/output.txt && cut -c 15-
+export TF_DIST_ID=sed -n 2p ../GITHUB_OUTPUT/output.txt && cut -c 15-
 
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --content-type "text/html" --exclude "*.css" --exclude "*.js"
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --exclude "*" --include "*.css" --include "*.js"

--- a/ci/tasks/build_and_deploy/deploy.sh
+++ b/ci/tasks/build_and_deploy/deploy.sh
@@ -16,5 +16,9 @@ aws sts assume-role --output text \
 export AWS_ACCESS_KEY_ID="$(cat AccessKeyId)"
 export AWS_SECRET_ACCESS_KEY="$(cat SecretAccessKey)"
 export AWS_SESSION_TOKEN="$(cat SessionToken)"
+export TF_DIST_ID=sed -n "${2}p" ../GITHUB_OUTPUT/output.txt && cut -c 15-
+
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --content-type "text/html" --exclude "*.css" --exclude "*.js"
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --exclude "*" --include "*.css" --include "*.js"
+
+aws cloudfront create-invalidation --distribution-id $TF_DIST_ID -- paths "/*"

--- a/ci/tasks/build_and_deploy/deploy.sh
+++ b/ci/tasks/build_and_deploy/deploy.sh
@@ -16,7 +16,7 @@ aws sts assume-role --output text \
 export AWS_ACCESS_KEY_ID="$(cat AccessKeyId)"
 export AWS_SECRET_ACCESS_KEY="$(cat SecretAccessKey)"
 export AWS_SESSION_TOKEN="$(cat SessionToken)"
-export TF_DIST_ID=sed -n 2p ../GITHUB_OUTPUT/output.txt && cut -c 15-
+export TF_DIST_ID=$(sed -n 2p ../GITHUB_OUTPUT/output.txt && cut -c 15-)
 
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --content-type "text/html" --exclude "*.css" --exclude "*.js"
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --exclude "*" --include "*.css" --include "*.js"

--- a/ci/tasks/build_and_deploy/deploy.sh
+++ b/ci/tasks/build_and_deploy/deploy.sh
@@ -21,4 +21,4 @@ export TF_DIST_ID=sed -n 2p ../GITHUB_OUTPUT/output.txt && cut -c 15-
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --content-type "text/html" --exclude "*.css" --exclude "*.js"
 aws s3 sync ./build s3://sml-portal-$TF_VAR_environment-$workspace_name --delete --exclude "*" --include "*.css" --include "*.js"
 
-aws cloudfront create-invalidation --distribution-id $TF_DIST_ID -- paths "/*"
+aws cloudfront create-invalidation --distribution-id $TF_DIST_ID --paths "/*"

--- a/ci/tasks/build_and_deploy/deploy.yml
+++ b/ci/tasks/build_and_deploy/deploy.yml
@@ -9,7 +9,7 @@ image_resource:
 
 inputs:
   - name: repo
-
+  - name: GITHUB_OUTPUT
 run:
   path: sh
   dir: repo


### PR DESCRIPTION
# Description

Amendments to the Concourse pipeline to automatically invalidate all caches on the deployed cloudfront instance during CI/CD execution, allowing users to see updates to deployment environments immediately after deployment and no longer need to wait for the cache to expire/manually invalidate the cache

If you have not checked any of the lists below explain why here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [ ] Code to be commented on where applicable 
- [ ] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [ ] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
- [ ] For a change that needs to be deployed in a release I have a commit with the fix:, feat: or BREAKING CHANGE:
tags and will copy this commit message to the squash
- [x] For a change that does not affect the deployed code I have added a commit with ci:, docs: or test:
depending upon which area of the solution was affected

Note when merging, squash commit must begin with one of the following tags:
"BREAKING CHANGE", "feat", "fix", "ci", "docs", "test"

Usage

BREAKING CHANGE: any change that breaks current functionality and may cause compatibility errors to users upgrading
    E.G BREAKING CHANGE: refactored method x to take variable y as input (changed from variable z)

feat: A new feature
    E.G feat: adding method x to future methods table

fix: A bug fix
    E.G fix: amending page for method x to show correct release version

ci: Changes to our CI configuration files and scripts (Concourse)

docs: Documentation only changes

test: Adding missing tests or correcting existing tests
