### PR TITLE
adding list tags to lambda role

### DIFF
--- a/deployment_role_bootstrap/role.tf
+++ b/deployment_role_bootstrap/role.tf
@@ -214,6 +214,7 @@ resource "aws_iam_policy" "deployment_role_sml_policy" {
               "Action": [
                 "lambda:CreateFunction",
                 "lambda:GetFunction",
+                "lambda:ListTags",
                 "lambda:TagResource",
                 "lambda:UpdateFunctionCode",
                 "lambda:RemovePermission",


### PR DESCRIPTION
Adding listtags to lambda function, AWS discovered a bug where the GetFunction permission inherited the listtags permission when it shouldn't, this will be patched next month which will cause errors if we use the listtags api