### PR TITLE
Fix GitHub Actions methods deletion bug

### DIFF
--- a/.github/workflows/contentful-update.yml
+++ b/.github/workflows/contentful-update.yml
@@ -28,6 +28,7 @@ jobs:
           echo "GITHUB_EVENT_SPACE_ID=${{ github.event.client_payload.spaceID }}" >> $GITHUB_ENV
           echo "GITHUB_EVENT_USER_ID=${{ github.event.client_payload.userID }}" >> $GITHUB_ENV
           echo "GITHUB_EVENT_ENTITY_ID=${{ github.event.client_payload.entityID }}" >> $GITHUB_ENV
+          echo "GITHUB_EVENT_CHANGE_TYPE=${{ github.event.client_payload.changeType }}" >> $GITHUB_ENV
 
       - name: Pull latest changes and rebase
         run: |

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -130,55 +130,71 @@ get_user_full_name "$space_id" "$user_id" "$CONTENTFUL_TOKEN"
 if [ $? -eq 0 ]; then
     echo "User full name: ${update_details["full_name"]}"
 
-    # Get the entry by ID
-    entry_id="${GITHUB_EVENT_ENTITY_ID}"
-    get_entry_by_id "$space_id" "$environment" "$entry_id" "$CONTENTFUL_CDA_TOKEN"
-
-    # Check the return from the function
-    if [ $? -eq 0 ]; then
-        # Remove milliseconds and 'Z'
-        cleaned_timestamp=$(echo "${update_details["updated_at"]}" | sed -E 's/\.[0-9]{3}Z$//' | sed 's/T/ /')
-
-        # Detect if GNU date is available
-        if date --version &>/dev/null; then
-            # GNU date (Linux)
-            formatted_timestamp=$(date -d "$cleaned_timestamp" +"%d/%m/%Y at %I:%M:%S %p")
-        else
-            # macOS date
-            formatted_timestamp=$(date -j -f "%Y-%m-%d %H:%M:%S" "$cleaned_timestamp" +"%d/%m/%Y at %I:%M:%S %p")
-        fi
-
-        fields=$(echo "${update_details["fields"]}" | jq -r 'to_entries[] | "\(.key): \(.value)"')
-
+    if [ "${GITHUB_EVENT_CHANGE_TYPE}" == "DeletedEntry"]; then
         {
-        echo "# CMS Update: $formatted_timestamp"
+        echo "# CMS Update: Content Deletion"
         echo ""
         echo "Editor: ${update_details["full_name"]}"
         echo ""
-        echo "Environment: ${update_details["environment"]}"
+        echo "Environment: ${environment}"
         echo ""
-        echo "Content Type: ${update_details["content_type"]}"
+        echo "Change Type: ${$GITHUB_EVENT_CHANGE_TYPE}"
         echo ""
-        echo "Revision: ${update_details["revision"]}"
+        echo "Entry ID: ${GITHUB_EVENT_ENTITY_ID}"
         echo ""
-        echo "Updated At: ${update_details["updated_at"]}"
+        echo "This entry was deleted"
         echo ""
-        echo "Content Updated:"
-        echo ""
-        echo '```txt'
-        echo "$fields"
-        echo '```'
-        echo ""
-        echo "— $formatted_timestamp —"
-        echo ""
-
         } >> "$changelog_file"
-
     else
-        echo "Failed to retrieve entry details."
-        exit 1
-    fi
+        # Get the entry by ID
+        entry_id="${GITHUB_EVENT_ENTITY_ID}"
+        get_entry_by_id "$space_id" "$environment" "$entry_id" "$CONTENTFUL_CDA_TOKEN"
 
+        # Check the return from the function
+        if [ $? -eq 0 ]; then
+            # Remove milliseconds and 'Z'
+            cleaned_timestamp=$(echo "${update_details["updated_at"]}" | sed -E 's/\.[0-9]{3}Z$//' | sed 's/T/ /')
+
+            # Detect if GNU date is available
+            if date --version &>/dev/null; then
+                # GNU date (Linux)
+                formatted_timestamp=$(date -d "$cleaned_timestamp" +"%d/%m/%Y at %I:%M:%S %p")
+            else
+                # macOS date
+                formatted_timestamp=$(date -j -f "%Y-%m-%d %H:%M:%S" "$cleaned_timestamp" +"%d/%m/%Y at %I:%M:%S %p")
+            fi
+
+            fields=$(echo "${update_details["fields"]}" | jq -r 'to_entries[] | "\(.key): \(.value)"')
+
+            {
+            echo "# CMS Update: $formatted_timestamp"
+            echo ""
+            echo "Editor: ${update_details["full_name"]}"
+            echo ""
+            echo "Environment: ${update_details["environment"]}"
+            echo ""
+            echo "Content Type: ${update_details["content_type"]}"
+            echo ""
+            echo "Revision: ${update_details["revision"]}"
+            echo ""
+            echo "Updated At: ${update_details["updated_at"]}"
+            echo ""
+            echo "Content Updated:"
+            echo ""
+            echo '```txt'
+            echo "$fields"
+            echo '```'
+            echo ""
+            echo "— $formatted_timestamp —"
+            echo ""
+
+            } >> "$changelog_file"
+
+        else
+            echo "Failed to retrieve entry details."
+            exit 1
+        fi
+    fi
 else
     echo "Failed to retrieve user full name."
     exit 1


### PR DESCRIPTION
# Description

When deleting entries in the preprod environment in Contentful, a GitHub Action is triggered to record the change to the content. It does this by sending a GET request on the ID of the entry that was deleted to the Contentful API. However, the entry no longer exists, so the Contentful API returns a 404 error. This pull request modifies the scripts to ensure that deletion of entries can be recorded via a different method.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical Enhancements

# Checklist:

If any of these are not completed, please explain why in the notes.

## **Definition of Done**
**Code and merges**

- [x] Code to be commented on where applicable 
- [x] Documentation updated where required 
- [x] Have considered non-functional requirements such as Security, Performance, Scalability, and Fault Tolerance
- [x] I have linted the code

**Testing**

- [x] All levels of acceptance test are passing (automated, integration, manual, accessibility, etc.)
- [x] I have run the behave command to check the selenium behaviour tests pass locally
- [x] Acceptance criteria met

**Other Checks**
- [x] I have performed a self-review of my own code
- [x] I have checked for spelling errors
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes don't break anything unexpected
- [x] I have checked and updated the security.txt file where required
- [x] Up to date with the main branch
- [ ] For a change that needs to be deployed in a release I have a commit with the fix:, feat: or BREAKING CHANGE:
tags and will copy this commit message to the squash
- [ ] For a change that does not affect the deployed code I have added a commit with ci:, docs: or test:
depending upon which area of the solution was affected

Note when merging, squash commit must begin with one of the following tags:
"BREAKING CHANGE", "feat", "fix", "ci", "docs", "test"

Usage

BREAKING CHANGE: any change that breaks current functionality and may cause compatibility errors to users upgrading
    E.G BREAKING CHANGE: refactored method x to take variable y as input (changed from variable z)

feat: A new feature
    E.G feat: adding method x to future methods table

fix: A bug fix
    E.G fix: amending page for method x to show correct release version

ci: Changes to our CI configuration files and scripts (Concourse)

docs: Documentation only changes

test: Adding missing tests or correcting existing tests
