### PR TITLE
Amending prod pipeline build to use build_type 3 (production deploy) …

### DIFF
--- a/ci/live-pipeline.yml
+++ b/ci/live-pipeline.yml
@@ -380,7 +380,7 @@ jobs:
               SPACE_ID: ((contentful_space_id))
               CDA_KEY: ((contentful_delivery_api_key_prod))
               CONTENTFUL_ENVIRONMENT: prod
-              BUILD_TYPE: 2
+              BUILD_TYPE: 3
               GH_TOKEN: ((github_access_token))
               SIGNING_KEY: ((github_ons_spp_machine_user_gpg_key_private))
 


### PR DESCRIPTION
Amending Live-sml-pipeline to use the correct build type when creating productions build files, was previously referring to the rollback steps which caused errors