### PR TITLE
Fixing issues with Email and 404 error with contentful

### DIFF
--- a/ci/tasks/util/send_email.py
+++ b/ci/tasks/util/send_email.py
@@ -4,7 +4,7 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 templates = {
     "pass": "94772cac-74b6-4b12-afca-11e525e3365a",
-    "fail": "45a2acad-7f3b-4993-aac5-2ed618c26787",
+    "failure": "45a2acad-7f3b-4993-aac5-2ed618c26787",
     "build_started": "fd5fb69b-ec9c-408b-b761-5ff11266f50b"
 }
 firstname = os.environ["FIRSTNAME"]

--- a/sml_builder/__init__.py
+++ b/sml_builder/__init__.py
@@ -10,7 +10,7 @@ Markdown(app)
 app.jinja_env.add_extension("jinja2.ext.do")
 app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
-app.config['FREEZER_IGNORE_404_NOT_FOUND'] = True
+app.config["FREEZER_IGNORE_404_NOT_FOUND"] = True
 app.config["FREEZER_DEFAULT_MIMETYPE"] = "text/html"
 app.config["FREEZER_DESTINATION"] = "../build"
 

--- a/sml_builder/__init__.py
+++ b/sml_builder/__init__.py
@@ -10,7 +10,7 @@ Markdown(app)
 app.jinja_env.add_extension("jinja2.ext.do")
 app.jinja_env.trim_blocks = True
 app.jinja_env.lstrip_blocks = True
-
+app.config['FREEZER_IGNORE_404_NOT_FOUND'] = True
 app.config["FREEZER_DEFAULT_MIMETYPE"] = "text/html"
 app.config["FREEZER_DESTINATION"] = "../build"
 


### PR DESCRIPTION
# Description

Send_email.py error'd out when the build process failed, this has been fixed to correctly send the email. Additionally. Freeze.py should no longer error if it finds a 404 page (this can happen as freeze.py creates a manifest of all expected links when its run and attempts to access them. however as pages are edited and deleted on contentful these expected links can causes issues as local files can add to the expected manifest list, even though local files are not used in the build.
