### PR TITLE
Fixing pyproject to use correct package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "sml-catalogue"
+name = "sml_builder"
 version = "1.12.0"
 description = "This repo contains the build environment and code to generate and upload the Statistical Methods Library (SML) Portal Web Application."
 authors = []


### PR DESCRIPTION
# Description

Poetry was failing as due to poetry 2.0 update our project name was now wrong (project should be a subfolder from where the pyproject is, not the current directory)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical Enhancements
